### PR TITLE
Feed collector output temperature setpoint into PTES deck

### DIFF
--- a/PTES/create_parameters_ddck_file.py
+++ b/PTES/create_parameters_ddck_file.py
@@ -153,6 +153,7 @@ def test_get_solved_equations() -> None:
                 "scaling": "relative_to_collector_area_kg_per_h_m2",
                 "value": 15.0,
             },
+            "output_temperature_setpoint_degC": 100.0,
         },
         "storage": {
             "volume": {"scaling": "absolute_m3", "value": 400},
@@ -178,6 +179,8 @@ def _create_parameters_ddck_contents(parameters: _pptes.PtesParameters) -> str:
 
     unscaledYearlyHeatDemandMWh = sum(demand.hourly_heat_demand_MW)
 
+    collector_field = parameters.collector_field
+
     port_heights = parameters.storage.ports_relative_heights_1
 
     formatted_specified_and_solved_variables_block = (
@@ -198,6 +201,8 @@ $QSnkQUnscaled_MWh = {unscaledYearlyHeatDemandMWh}
 $QSnkQ_MWh = $QSnkScalingFactor*$QSnkQUnscaled_MWh
 
 $HPsizeUsed = $QSnkQ_MWh/10
+
+$TSetColl = {collector_field.output_temperature_setpoint_degC}
 
 $psPtesPortsHeightRelTop = {port_heights.top}
 $psPtesPortsHeightRelMiddle = {port_heights.middle}

--- a/PTES/ddck/control/control.ddck
+++ b/PTES/ddck/control/control.ddck
@@ -9,7 +9,7 @@ TRoomStore = tAmb
 ** Collectors
 MfrPuCollPri = SolarControlPuPriOn * CollMfrOut !MfrPuCollPriSet
 MfrPuCollSec = SolarControlPuSecOn * MfrPuCollPri * Lloop2Cp/Lloop5Cp !1000.0
-TSetColl = TSetDem + 20
+** TSetColl is defined in parameters\parameters.ddck
 
 ** Auxiliary source
 MfrQSrc = QSrcM

--- a/PTES/ddck/control/control.ddck
+++ b/PTES/ddck/control/control.ddck
@@ -9,7 +9,7 @@ TRoomStore = tAmb
 ** Collectors
 MfrPuCollPri = SolarControlPuPriOn * CollMfrOut !MfrPuCollPriSet
 MfrPuCollSec = SolarControlPuSecOn * MfrPuCollPri * Lloop2Cp/Lloop5Cp !1000.0
-** TSetColl is defined in parameters\parameters.ddck
+! TSetColl is defined in parameters\parameters.ddck
 
 ** Auxiliary source
 MfrQSrc = QSrcM


### PR DESCRIPTION
The generated `parameters.ddck` now defines the TRNSYS global `$TSetColl` from the `output_temperature_setpoint_degC` collector field parameter, which `Coll/Type1357.ddck` consumes as the collector outlet temperature setpoint.

- `PTES/create_parameters_ddck_file.py`: write `$TSetColl = <value>` into the generated deck and add the field to the embedded test data (test passes).
- `PTES/ddck/control/control.ddck`: remove the hard-coded `TSetColl = TSetDem + 20` so the parameter is the single source of the setpoint.

TTES and BTES are intentionally untouched.

Part of the collector output temperature setpoint feature, together with the PRs in `client`, `server`, `scheduler` and `runner`.

https://claude.ai/code/session_01AzkCni2kjpPAwfneoPj9Ck

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzkCni2kjpPAwfneoPj9Ck)_