### PR TITLE
Hoist PTES setpoint and maximum storage temperatures out of the ddcks

### DIFF
--- a/BTES/run_BTES.config
+++ b/BTES/run_BTES.config
@@ -42,9 +42,6 @@ string addResultsFolder "results"
 deck QSnkQ_MWh 10000
 deck TSetDem 70
 
-###### BOILER ######
-deck TSetBolr TSetDem
-
 ###### TANK ######
 deck TesTmax_Tes1 200
 deck TesTini_Tes1 30

--- a/BTES/run_BTES.config
+++ b/BTES/run_BTES.config
@@ -42,6 +42,9 @@ string addResultsFolder "results"
 deck QSnkQ_MWh 10000
 deck TSetDem 70
 
+###### BOILER ######
+deck TSetBolr TSetDem
+
 ###### TANK ######
 deck TesTmax_Tes1 200
 deck TesTini_Tes1 30

--- a/PTES/create_parameters_ddck_file.py
+++ b/PTES/create_parameters_ddck_file.py
@@ -163,6 +163,12 @@ def test_get_solved_equations() -> None:
                 "bottom": 0.05,
             },
         },
+        "temperatures": {
+            "demand_setpoint_degC": 80.0,
+            "boiler_output_setpoint_degC": 80.0,
+            "heat_pump_output_setpoint_degC": 80.0,
+            "storage_maximum_degC": 85.0,
+        },
     }
 
     parameters = _pptes.PtesParameters(**data)
@@ -180,6 +186,8 @@ def _create_parameters_ddck_contents(parameters: _pptes.PtesParameters) -> str:
     unscaledYearlyHeatDemandMWh = sum(demand.hourly_heat_demand_MW)
 
     collector_field = parameters.collector_field
+
+    temperatures = parameters.temperatures
 
     port_heights = parameters.storage.ports_relative_heights_1
 
@@ -203,6 +211,11 @@ $QSnkQ_MWh = $QSnkScalingFactor*$QSnkQUnscaled_MWh
 $HPsizeUsed = $QSnkQ_MWh/10
 
 $TSetColl = {collector_field.output_temperature_setpoint_degC}
+
+$TSetDem = {temperatures.demand_setpoint_degC}
+$TSetBolr = {temperatures.boiler_output_setpoint_degC}
+$TSetHp = {temperatures.heat_pump_output_setpoint_degC}
+$TTesMax = {temperatures.storage_maximum_degC}
 
 $psPtesPortsHeightRelTop = {port_heights.top}
 $psPtesPortsHeightRelMiddle = {port_heights.middle}

--- a/PTES/ddck/control/HP_temp_controller.ddck
+++ b/PTES/ddck/control/HP_temp_controller.ddck
@@ -7,7 +7,7 @@ frCondMin = 0.20		    ! chosen without any knowledge of actual system
 frCondMax = 0.99			! chosen without any knowledge of actual system
 frCondMaxInc = 3.0
 frCondMaxDec = -3.0 !-0.4
-SetTHp = $TSetDem
+SetTHp = $TSetHp
 freezeMode = NOT($HPIsOn)
 
 EQUATIONS 1

--- a/PTES/ddck/control/control.ddck
+++ b/PTES/ddck/control/control.ddck
@@ -18,7 +18,7 @@ MfrSources = MfrPuCollSec + MfrPuSrcSec
 
 ** Demand
 MfrQSnk = QSnkM ! 500
-! TSetDem is defined in parameters\parameters.ddck or the run config
+! TSetDem is defined in parameters\parameters.ddck
 
 ** HX
 xFracValHXPri = NOT(ValHXOut)

--- a/PTES/ddck/control/control.ddck
+++ b/PTES/ddck/control/control.ddck
@@ -18,7 +18,7 @@ MfrSources = MfrPuCollSec + MfrPuSrcSec
 
 ** Demand
 MfrQSnk = QSnkM ! 500
-TSetDem = 50
+! TSetDem is defined in parameters\parameters.ddck or the run config
 
 ** HX
 xFracValHXPri = NOT(ValHXOut)

--- a/PTES/ddck/control/variables.ddck
+++ b/PTES/ddck/control/variables.ddck
@@ -22,7 +22,7 @@ ValStratControlTIn = TTee9_ValStrat
 ** Capacity control for HP
 EQUATIONS #
 HpControlTControlled = HPTCondOut
-HpControlTSet = TSetDem
+HpControlTSet = TSetHp
 HpControlOn = HPIsOn
 
 

--- a/PTES/run_PTES.config
+++ b/PTES/run_PTES.config
@@ -43,6 +43,9 @@ deck QSnkQ_MWh 30000
 deck TSetDem 80
 deck QSnkdT 30
 
+###### BOILER ######
+deck TSetBolr TSetDem
+
 ###### SOURCE ######
 deck QSrcQ_MWh 0
 
@@ -53,8 +56,7 @@ deck pitStoreStHeight 16
 variation VTes pitStoreStVolume 100000 # 200000 300000 500000
 #variation VTes szVperDemand_m3_per_MWh 1 2 5 10
 #deck pitStoreStVolume szVperDemand_m3_per_MWh*QSnkQ_MWh
-deck SolarControlTTesMax 85 # Maximum PTES temperature
-deck SolarControlTTesMin SolarControlTTesMax-10
+deck TTesMax 85 # Maximum PTES temperature
 
 #deck pitStorecSoil 2800
 deck pitStorekSoil 6.48
@@ -74,6 +76,7 @@ deck HPsizeUsed QSnkQ_MWh/10 #500
 deck HPQLoadMax_kW QSnkQ_MWh/10
 deck HpAct 1
 deck HPtCondMax 500
+deck TSetHp TSetDem
 
 ###### HX ######
 deck HxUA_kW_K CollAcollAp*1*Collc0/HxLMTDNom # 1000

--- a/PTES/run_PTES.config
+++ b/PTES/run_PTES.config
@@ -43,9 +43,6 @@ deck QSnkQ_MWh 30000
 deck TSetDem 80
 deck QSnkdT 30
 
-###### BOILER ######
-deck TSetBolr TSetDem
-
 ###### SOURCE ######
 deck QSrcQ_MWh 0
 
@@ -56,7 +53,6 @@ deck pitStoreStHeight 16
 variation VTes pitStoreStVolume 100000 # 200000 300000 500000
 #variation VTes szVperDemand_m3_per_MWh 1 2 5 10
 #deck pitStoreStVolume szVperDemand_m3_per_MWh*QSnkQ_MWh
-deck TTesMax 85 # Maximum PTES temperature
 
 #deck pitStorecSoil 2800
 deck pitStorekSoil 6.48
@@ -76,7 +72,6 @@ deck HPsizeUsed QSnkQ_MWh/10 #500
 deck HPQLoadMax_kW QSnkQ_MWh/10
 deck HpAct 1
 deck HPtCondMax 500
-deck TSetHp TSetDem
 
 ###### HX ######
 deck HxUA_kW_K CollAcollAp*1*Collc0/HxLMTDNom # 1000

--- a/PTES/run_PTES_fast.config
+++ b/PTES/run_PTES_fast.config
@@ -38,7 +38,7 @@ string trnsysExePath "C:\Users\damian.birchler\src\resultes\runner\create-disk-i
 string scaling "False" #"toDemand"
 
 ###### DEMAND ######
-deck TSetDem 80
+# TSetDem is defined in parameters\parameters.ddck
 
 ###### SOURCE ######
 deck QSrcQ_MWh 0
@@ -47,8 +47,7 @@ deck QSrcQ_MWh 0
 deck pitStoreIniT 40
 deck pitStoreSlAng 30
 deck pitStoreStHeight 10
-deck SolarControlTTesMax 85 # Maximum PTES temperature
-deck SolarControlTTesMin SolarControlTTesMax-10
+# TTesMax (maximum PTES temperature) is defined in parameters\parameters.ddck
 deck pitStorekSoil 6.48
 ###### COLLECTOR ######
 deck CollNbModTot CollAcollAp/CollAMod

--- a/ci/data/ptes.json.template
+++ b/ci/data/ptes.json.template
@@ -8790,7 +8790,8 @@
                     "a1_kW_per_m2_per_K": 4.16e-3,
                     "a2_kW_per_m2_per_K2": 0.0089e-3
                 },
-                "type": "flat-plate"
+                "type": "flat-plate",
+                "output_temperature_setpoint_degC": 100.0
             },
             "storage": {
                 "volume": {
@@ -8802,6 +8803,12 @@
                     "middle": 0.50,
                     "bottom": 0.05
                 }
+            },
+            "temperatures": {
+                "demand_setpoint_degC": 80.0,
+                "boiler_output_setpoint_degC": 80.0,
+                "heat_pump_output_setpoint_degC": 80.0,
+                "storage_maximum_degC": 85.0
             }
         }
     }

--- a/common/ddck/Bolr/type6.ddck
+++ b/common/ddck/Bolr/type6.ddck
@@ -39,7 +39,7 @@ EQUATIONS #
 ***********************************
 EQUATIONS #
 on = 1
-Tset = $TSetDem
+Tset = $TSetBolr
 tRoomStore = $tamb
 
 ***********************************

--- a/common/ddck/Hp/type4052.ddck
+++ b/common/ddck/Hp/type4052.ddck
@@ -35,7 +35,7 @@ EQUATIONS #
 ** inputs from other ddcks
 *************************************
 EQUATIONS #
-TWanted = $TSetDem
+TWanted = $TSetHp
 QWanted = 0 ! Not relevant for this control mode
 QWanted_kW = QWanted/1000 ! Not relevant for this control mode
 On = 1

--- a/common/ddck/SolarControl/Stagnation.ddck
+++ b/common/ddck/SolarControl/Stagnation.ddck
@@ -45,12 +45,11 @@ TStagRec = [1,3]
 ** Control logic
 ***********************************
 
-** Maximum TES temperature
-CONSTANTS #
-TTesMax = 95
+** The maximum TES temperature, TTesMax, is defined in the
+** parameters.ddck or the run config of the respective system
 
 EQUATIONS #
-Stag = NOT(StagRec)*GT(TStagRec,TTesMax)*GT($IT_H, 0) + StagRec*GT($IT_H, 0)
+Stag = NOT(StagRec)*GT(TStagRec,$TTesMax)*GT($IT_H, 0) + StagRec*GT($IT_H, 0)
 StagDays = GT(Stag,StagRec)*(StagDaysRec+1) + LE(Stag,StagRec)*StagDaysRec
 
 ***********************************


### PR DESCRIPTION
Make the demand setpoint (`TSetDem`), boiler output setpoint (`TSetBolr`), heat pump output setpoint (`TSetHp`) and maximum storage temperature (`TTesMax`) externally settable for the PTES system instead of hardcoding them in the ddcks.

**How the temperatures were wired before this change** (everything derived from `TSetDem`):

- `TSetDem = 50` was hardcoded in `PTES/ddck/control/control.ddck` and overridden by `deck TSetDem 80` in the run configs.
- Boiler setpoint: `Tset = $TSetDem` in `common/ddck/Bolr/type6.ddck` (offset 0).
- Heat pump output setpoint: `TWanted = $TSetDem` in `common/ddck/Hp/type4052.ddck` and `HpControlTSet = TSetDem` in `PTES/ddck/control/variables.ddck` (offset 0).
- Maximum storage temperature: `TTesMax = 95` hardcoded in `common/ddck/SolarControl/Stagnation.ddck`, overridden by `deck SolarControlTTesMax 85` in the configs (effectively `TSetDem + 5`).

**Changes:**

- Remove the hardcoded definitions from `control.ddck` and `Stagnation.ddck`.
- Reference the new `TSetBolr`/`TSetHp` globals from the common boiler and heat pump ddcks and the PTES HP control wiring.
- `create_parameters_ddck_file.py` now writes all four temperatures into `parameters.ddck` from the values passed in from the UI, and the corresponding `deck` overrides are dropped from `run_PTES_fast.config` (the config used by the web pipeline) so the UI values take effect.
- `run_PTES.config` and `run_BTES.config` (which don't use `parameters.ddck`) define the new variables themselves, preserving their previous behaviour (`TSetBolr = TSetHp = TSetDem`, `TTesMax = 85`).
- `ci/data/ptes.json.template` gains the new `temperatures` block (and the collector `output_temperature_setpoint_degC` it was missing).
- The unused `SolarControlTTesMin` config entries are dropped (no ddck consumes them).

`myTHigh = $TSetDem` in `ValHP.ddck` intentionally keeps using the demand setpoint: it decides whether the HP is needed to lift the storage/HX outlet up to the *demand* temperature.

Requires resultes-net/pydantic-models#1.

Closes resultes-net/issues#20

https://claude.ai/code/session_01XyBhZB43beMUGvdMomVQ3m

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyBhZB43beMUGvdMomVQ3m)_